### PR TITLE
do not export `gate`

### DIFF
--- a/src/gate.jl
+++ b/src/gate.jl
@@ -2,10 +2,7 @@ module Gate
 
 using PyCall
 
-export gate
-
 qulacs = PyNULL()
-gate = PyNULL()
 
 const gate_classes = [
     :Adaptive, :RX,
@@ -83,7 +80,6 @@ end
 
 function __init__()
     copy!(qulacs, pyimport("qulacs"))
-    copy!(gate, pyimport("qulacs.gate"))
 end
 
 end # module Gate

--- a/src/qulacs.jl
+++ b/src/qulacs.jl
@@ -43,7 +43,6 @@ for class in qulacs_class
     end
 end
 
-# Write your package code here.
 function __init__()
     copy!(qulacs, pyimport("qulacs"))
 end


### PR DESCRIPTION
Since we have already export `qulacs(=pyimport("qulacs"))` object, we no longer need to export PyObject `gate` 