### PR TITLE
Wrap qulacs with macro

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -60,9 +60,4 @@ jobs:
             using Pkg
             Pkg.develop(PackageSpec(path=pwd()))
             Pkg.instantiate()'
-      - run: |
-          julia --project=docs -e '
-            using Documenter: doctest
-            using PkgTemplates
-            doctest(PkgTemplates)'
       - run: julia --project=docs docs/make.jl

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,7 +49,7 @@ jobs:
       - run: pip3 install qulacs
       - uses: julia-actions/setup-julia@v1
         with:
-          version: '1'
+          version: '1.6'
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-docdeploy@v1
         env:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -60,4 +60,4 @@ jobs:
             using Documenter: DocMeta, doctest
             using Kyulacs
             DocMeta.setdocmeta!(Kyulacs, :DocTestSetup, :(using Kyulacs); recursive=true)
-            doctest(Kyulacs)'
+            doctest(Kyulacs, doctest=false)'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -57,7 +57,12 @@ jobs:
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
       - run: |
           julia --project=docs -e '
-            using Documenter: DocMeta, doctest
-            using Kyulacs
-            DocMeta.setdocmeta!(Kyulacs, :DocTestSetup, :(using Kyulacs); recursive=true)
-            doctest(Kyulacs, doctest=false)'
+            using Pkg
+            Pkg.develop(PackageSpec(path=pwd()))
+            Pkg.instantiate()'
+      - run: |
+          julia --project=docs -e '
+            using Documenter: doctest
+            using PkgTemplates
+            doctest(PkgTemplates)'
+      - run: julia --project=docs docs/make.jl

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,4 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Kyulacs = "b612f6cd-3a6e-4e62-9d6b-447ae96af911"
+LiveServer = "16fef848-5104-11e9-1b77-fb7a48bbb589"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,7 +1,12 @@
+using Markdown
 using Kyulacs
+using Kyulacs:LazyHelp
 using Documenter
+import Documenter.Utilities.MDFlatten: mdflatten
 
 #DocMeta.setdocmeta!(Kyulacs, :DocTestSetup, :(using Kyulacs); recursive=true)
+
+mdflatten(io:IOBuffer, h::LazyHelp, md::Markdown.MD) = nothing
 
 makedocs(;
     modules=[Kyulacs],

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,7 +1,7 @@
 using Kyulacs
 using Documenter
 
-DocMeta.setdocmeta!(Kyulacs, :DocTestSetup, :(using Kyulacs); recursive=true)
+#DocMeta.setdocmeta!(Kyulacs, :DocTestSetup, :(using Kyulacs); recursive=true)
 
 makedocs(;
     modules=[Kyulacs],
@@ -16,6 +16,7 @@ makedocs(;
     pages=[
         "Home" => "index.md",
     ],
+    doctest=false,
 )
 
 deploydocs(;

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -6,7 +6,7 @@ import Documenter.Utilities.MDFlatten: mdflatten
 
 #DocMeta.setdocmeta!(Kyulacs, :DocTestSetup, :(using Kyulacs); recursive=true)
 
-mdflatten(io:IOBuffer, h::LazyHelp, md::Markdown.MD) = nothing
+mdflatten(io::IOBuffer, h::LazyHelp, md::Markdown.MD) = nothing
 
 makedocs(;
     modules=[Kyulacs],

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -9,3 +9,6 @@ Documentation for [Kyulacs](https://github.com/terasakisatoshi/Kyulacs.jl).
 ```@index
 ```
 
+```@autodocs
+Modules = [Kyulacs.Qulacs, Kyulacs.Gate, Kyulacs.State, Kyulacs.Circuit, Kyulacs.QuantumOperator, Kyulacs.ObservableFunctions]
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -10,5 +10,5 @@ Documentation for [Kyulacs](https://github.com/terasakisatoshi/Kyulacs.jl).
 ```
 
 ```@autodocs
-Modules = [Kyulacs]
+Modules = [Kyulacs.Qulacs, Kyulacs.Gate, Kyulacs.State, Kyulacs.Circuit, Kyulacs.QuantumOperator, Kyulacs.ObservableFunctions]
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -9,6 +9,3 @@ Documentation for [Kyulacs](https://github.com/terasakisatoshi/Kyulacs.jl).
 ```@index
 ```
 
-```@autodocs
-Modules = [Kyulacs.Qulacs, Kyulacs.Gate, Kyulacs.State, Kyulacs.Circuit, Kyulacs.QuantumOperator, Kyulacs.ObservableFunctions]
-```

--- a/src/Kyulacs.jl
+++ b/src/Kyulacs.jl
@@ -1,6 +1,9 @@
 module Kyulacs
 
+using PyCall
 using Reexport
+
+include("pywraputils.jl")
 
 # qulacs
 include("qulacs.jl")

--- a/src/circuit.jl
+++ b/src/circuit.jl
@@ -2,12 +2,17 @@ module Circuit
 
 using PyCall
 
-const qulacs = PyNULL()
+import ..@pyfunc
+import ..@pyclass
+
+#const qulacs = PyNULL()
+const circuit = PyNULL()
 
 const circuit_class = [
     :QuantumCircuitOptimizer,
 ]
 
+#=
 for class in circuit_class
     @eval begin
         struct $class
@@ -32,9 +37,17 @@ for class in circuit_class
         export $(class)
     end
 end
+=#
 
+for class in circuit_class
+    @eval begin
+        @pyclass circuit $(class)
+        export $(class)
+    end
+end
 function __init__()
-    copy!(qulacs, pyimport("qulacs"))
+    #copy!(qulacs, pyimport("qulacs"))
+    copy!(circuit, pyimport("qulacs.circuit"))
 end
 
 end # module

--- a/src/gate.jl
+++ b/src/gate.jl
@@ -1,8 +1,11 @@
 module Gate
 
 using PyCall
+import ..@pyfunc
+import ..@pyclass
 
-qulacs = PyNULL()
+# qulacs = PyNULL()
+gate = PyNULL()
 
 const gate_classes = [
     :Adaptive, :RX,
@@ -34,6 +37,7 @@ const gate_classes = [
     :ProbabilisticInstrument,    #:to_matrix_gate,
 ]
 
+#=
 for class in gate_classes
     @eval begin
         struct $class
@@ -58,6 +62,14 @@ for class in gate_classes
         export $(class)
     end
 end
+=#
+
+for class in gate_classes
+    @eval begin
+        @pyclass gate $(class)
+        export $(class)
+    end
+end
 
 const gate_functions = [
     :add,
@@ -69,6 +81,7 @@ const gate_functions = [
     :to_matrix_gate,
 ]
 
+#=
 for func in gate_functions
     @eval begin
         function $(func)(args...; kwargs...)
@@ -77,9 +90,18 @@ for func in gate_functions
         export $(func)
     end
 end
+=#
+
+for func in gate_functions
+    @eval begin
+        @pyfunc gate $(func)
+        export $(func)
+    end
+end
 
 function __init__()
-    copy!(qulacs, pyimport("qulacs"))
+    #copy!(qulacs, pyimport("qulacs"))
+    copy!(gate, pyimport("qulacs.gate"))
 end
 
 end # module Gate

--- a/src/observable.jl
+++ b/src/observable.jl
@@ -2,7 +2,10 @@ module ObservableFunctions
 
 using PyCall
 
-qulacs = PyNULL()
+import ..@pyfunc
+
+#qulacs = PyNULL()
+observable = PyNULL()
 
 const observable_functions = [
     :create_observable_from_openfermion_file,
@@ -10,6 +13,7 @@ const observable_functions = [
     :create_split_observable,
 ]
 
+#=
 for func in observable_functions
     @eval begin
         function $(func)(args...; kwargs...)
@@ -18,9 +22,18 @@ for func in observable_functions
         export $(func)
     end
 end
+=#
+
+for func in observable_functions
+    @eval begin
+        @pyfunc observable $(func)
+        export $(func)
+    end
+end
 
 function __init__()
-    copy!(qulacs, pyimport("qulacs"))
+    #copy!(qulacs, pyimport("qulacs"))
+    copy!(observable, pyimport("qulacs.observable"))
 end
 
 end # module ObservableFunctions

--- a/src/pywraputils.jl
+++ b/src/pywraputils.jl
@@ -1,0 +1,83 @@
+struct LazyHelp
+    o::Any
+    keys::Tuple{Vararg{String}}
+end
+
+LazyHelp(o) = LazyHelp(o, ())
+LazyHelp(o, k::AbstractString) = LazyHelp(o, (k,))
+LazyHelp(o, k1::AbstractString, k2::AbstractString) = LazyHelp(o, (k1, k2))
+LazyHelp(o, s::Symbol) = LazyHelp(o, (string(s),))
+
+function show(io::IO, st, h::LazyHelp)
+    py"""
+    import inspect
+    def get_signature(f):
+        try:
+            return str(inspect.signature(f))
+        except ValueError:
+            return ""
+    """
+
+    o = h.o
+    for k in h.keys
+        o = o[k]
+    end
+
+    fname = hasproperty(o, "__name__") ? o.__name__ : ""
+    sig = hasproperty(o, "__call__") ? py"get_signature"(o) : ""
+    fdoc = hasproperty(o, "__doc__") ? o.__doc__ : ""
+
+    docstr = """
+        $(fname)$(sig)
+    $(fdoc)
+    """
+
+    print(io, docstr)
+end
+
+Base.show(io::IO, h::LazyHelp) = show(io, "text/plain", h)
+
+function Base.Docs.catdoc(hs::LazyHelp...)
+    Base.Docs.Text() do io
+        for h in hs
+            show(io, MIME"text/plain"(), h)
+        end
+    end
+end
+
+macro pyfunc(_pymod, _func)
+	pymod = _pymod |> esc
+	func = _func |> esc
+	quote
+		@doc LazyHelp($(pymod), nameof($(func))) 
+			function $(func)(args...; kwargs...)
+				$(pymod).$(func)(args...; kwargs...)
+			end
+	end
+end
+
+macro pyclass(_pymod, _class)
+	pymod = _pymod |> esc
+	class = _class |> esc
+	quote
+		@doc LazyHelp($(pymod), nameof($(class))) 
+			struct $(class)
+			    pyobj::$(PyObject)
+			    $(class)(args...; kwargs...) = new(getproperty($(pymod), nameof($class))(args...; kwargs...))
+			end
+
+		PyCall.PyObject(t::$(class)) = t.pyobj
+
+		function Base.propertynames(t::$(class))
+		    propertynames(getfield(t, :pyobj))
+		end
+
+		function Base.getproperty(t::$(class), s::Symbol)
+		    if s ∈ fieldnames($(class))
+		        return getfield(t, s)
+		    else
+		        return getproperty(getfield(t, :pyobj), s)
+		    end
+		end
+	end
+end

--- a/src/pywraputils.jl
+++ b/src/pywraputils.jl
@@ -51,7 +51,7 @@ macro pyfunc(_pymod, _func)
 	quote
 		@doc LazyHelp($(pymod), nameof($(func))) 
 			function $(func)(args...; kwargs...)
-				$(pymod).$(func)(args...; kwargs...)
+				getproperty($(pymod), nameof($(func)))(args...; kwargs...)
 			end
 	end
 end

--- a/src/quantum_operator.jl
+++ b/src/quantum_operator.jl
@@ -2,15 +2,19 @@ module QuantumOperator
 
 using PyCall
 
-qulacs = PyNULL()
+import ..@pyfunc
 
-const observable_functions = [
+#qulacs = PyNULL()
+quantum_operator = PyNULL()
+
+const quantum_operator_functions = [
     :create_quantum_operator_from_openfermion_file,
     :create_quantum_operator_from_openfermion_text,
     :create_split_quantum_operator,
 ]
 
-for func in observable_functions
+#=
+for func in quantum_operator_functions
     @eval begin
         function $(func)(args...; kwargs...)
             qulacs.quantum_operator.$(func)(args...; kwargs...)
@@ -18,9 +22,18 @@ for func in observable_functions
         export $(func)
     end
 end
+=#
+
+for func in quantum_operator_functions
+    @eval begin
+        @pyfunc quantum_operator $(func)
+        export $(func)
+    end
+end
 
 function __init__()
-    copy!(qulacs, pyimport("qulacs"))
+    #copy!(qulacs, pyimport("qulacs"))
+    copy!(quantum_operator, pyimport("qulacs.quantum_operator"))
 end
 
 end # module QuantumOperator

--- a/src/qulacs.jl
+++ b/src/qulacs.jl
@@ -2,6 +2,9 @@ module Qulacs
 
 using PyCall
 
+import ..@pyfunc
+import ..@pyclass
+
 export qulacs
 
 const qulacs = PyNULL()
@@ -18,6 +21,7 @@ const qulacs_class = [
     :QuantumGateMatrix,
 ]
 
+#=
 for class in qulacs_class
     @eval begin
         struct $class
@@ -39,6 +43,14 @@ for class in qulacs_class
             end
         end
 
+        export $(class)
+    end
+end
+=#
+
+for class in qulacs_class
+    @eval begin
+        @pyclass qulacs $(class)
         export $(class)
     end
 end

--- a/src/qulacs_gpu.jl
+++ b/src/qulacs_gpu.jl
@@ -1,6 +1,7 @@
 module GPU
 
 using PyCall
+import ..LazyHelp
 
 const qulacs = PyNULL()
 
@@ -11,7 +12,7 @@ const qulacs_class = [
 
 for class in qulacs_class
     @eval begin
-        struct $class
+        @doc LazyHelp(qulacs, nameof($(class))) struct $class
             pyobj::PyObject
             function $(class)(args...)
                 try

--- a/src/state.jl
+++ b/src/state.jl
@@ -1,9 +1,11 @@
 module State
 
 using PyCall
+import ..@pyfunc
 
-qulacs = PyNULL()
+#qulacs = PyNULL()
 
+state = PyNULL()
 const state_functions = [
     :inner_product,
     :tensor_product,
@@ -12,6 +14,7 @@ const state_functions = [
     :partial_trace,
 ]
 
+#=
 for func in state_functions
     @eval begin
         function $(func)(args...; kwargs...)
@@ -20,9 +23,18 @@ for func in state_functions
         export $(func)
     end
 end
+=#
+
+for func in state_functions
+    @eval begin
+        @pyfunc state $(func)
+        export $(func)
+    end
+end
 
 function __init__()
-    copy!(qulacs, pyimport("qulacs"))
+    #copy!(qulacs, pyimport("qulacs"))
+    copy!(state, pyimport("qulacs.state"))
 end
 
 end # module State


### PR DESCRIPTION
This PR enhances wrapping Python interface using Julia macro via `pywraputils.jl`.

Feature 1 `LazyHelp`
`pywraputils.jl` provides `LazyHelp` (similar to that of Plotly.jl or SciPy.jl) which allows us to access the Docstring of Python object defined in `__doc__`. For example Julia can tell us how to use `StateVector`

```julia
help?> StateVector
search: StateVector

    StateVector
StateVector(arg0: int) -> qulacs.QuantumState

StateVector
```

Feature 2 `@pyfunc, @pyclass`

these macros wrap python function and python class efficiently 👍 